### PR TITLE
[I-7]: Fix for Ctrl Key & Meta Key Crossword Override

### DIFF
--- a/pages/crossword.js
+++ b/pages/crossword.js
@@ -144,7 +144,7 @@ class Crossword extends React.PureComponent {
       } else {
         this.clearPreviousDownCell(row, col);
       }
-    } else if (typedLetter) {
+    } else if (typedLetter && !(event.ctrlKey || event.metaKey)) {
       event.preventDefault();
       const previousLetter = letters[row][col];
       letters[row][col] = typedLetter;


### PR DESCRIPTION
[I-7](https://github.com/benbrott/benbrott/issues/7): Fix for ctrl key and meta key not overriding crossword interactions